### PR TITLE
Use default configuration in datafusion runners

### DIFF
--- a/datafusion-python/sqlbench-datafusion-python.py
+++ b/datafusion-python/sqlbench-datafusion-python.py
@@ -14,13 +14,7 @@ def bench(data_path, query_path, num_queries):
         runtime = RuntimeConfig()\
             .with_disk_manager_os()\
             .with_greedy_memory_pool(64*1024*1024*1024)
-        config = {
-            'datafusion.execution.batch_size': '32768',
-            'datafusion.execution.parquet.pushdown_filters': 'true',
-            'datafusion.execution.parquet.reorder_filters': 'true',
-            'datafusion.execution.parquet.enable_page_index': 'true',
-            'datafusion.optimizer.filter_null_join_keys': 'false'
-        }
+        config = {}
         ctx = SessionContext(SessionConfig(config), runtime)
         print(ctx)
 

--- a/datafusion/src/main.rs
+++ b/datafusion/src/main.rs
@@ -108,11 +108,7 @@ pub async fn main() -> Result<()> {
     let query_path = format!("{}", opt.query_path.display());
     let output_path = format!("{}", opt.output.display());
 
-    let mut config = SessionConfig::new()
-        .with_target_partitions(opt.concurrency as usize)
-        .with_repartition_file_scans(true)
-        .set_bool("datafusion.optimizer.enable_round_robin_repartition", true)
-        .set_bool("datafusion.execution.coalesce_batches", false);
+    let mut config = SessionConfig::new().with_target_partitions(opt.concurrency as usize);
 
     if let Some(config_path) = &opt.config_path {
         let file = File::open(config_path)?;


### PR DESCRIPTION
Default settings should be optimal to run the queries
eg, setting `datafusion.execution.coalesce_batches` to `false` leads to suboptimal performance 